### PR TITLE
Add cabal file, update pandoc-types for Text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 !.gitignore
 !*.hs
 !*.md
+!*.cabal
+!LICENSE
+!example.md

--- a/GraphvizBlock.hs
+++ b/GraphvizBlock.hs
@@ -1,10 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module GraphvizBlock (graphvizBlock) where
 
-import Data.ByteString.Lazy.UTF8 (fromString)
 import Data.Digest.Pure.SHA (sha256, showDigest)
+import Data.Text (pack, unpack)
+import Data.Text.Lazy.Encoding ( encodeUtf8 )
+import Data.Text.Lazy ( fromStrict )
 import System.Exit (ExitCode (ExitSuccess))
 import System.Process (readProcessWithExitCode)
-import Text.Pandoc
+import Text.Pandoc.Definition
 
 graphvizBlock :: Maybe Format -> Block -> IO Block
 graphvizBlock (Just format) (CodeBlock (id, classes, keyvals) content)
@@ -12,30 +16,30 @@ graphvizBlock (Just format) (CodeBlock (id, classes, keyvals) content)
         case format of
           Format "html" ->
               do
-                (ec, out, err) <- readProcessWithExitCode "dot" ["-Tsvg", "-K" ++ layout] content
+                (ec, out, err) <- readProcessWithExitCode "dot" ["-Tsvg", "-K" <> layout] $ unpack content
                 return $ case ec of
                            ExitSuccess -> RawBlock (Format "html")
-                                 ("<div id=\"" ++ id ++ "\" class=\"graphviz\">" ++ out ++ "</div>")
-                           _ -> CodeBlock (id, classes, keyvals) err
+                                 ("<div id=\"" <> id <> "\" class=\"graphviz\">" <> pack out <> "</div>")
+                           _ -> CodeBlock (id, classes, keyvals) $ pack err
           Format "latex" ->
               do
                 (ec, out, err) <- readProcessWithExitCode
-                                  "dot2tex" ["--figonly", "--progoptions=-K" ++ layout] content
+                                  "dot2tex" ["--figonly", "--progoptions=-K" <> layout] $ unpack content
                 return $ if length err == 0
-                         then RawBlock (Format "latex") out
-                         else CodeBlock (id, classes, keyvals) err
+                         then RawBlock (Format "latex") $ pack out
+                         else CodeBlock (id, classes, keyvals) $ pack err
           _ ->
               do
                 (ec, out, err) <- readProcessWithExitCode
-                                  "dot" ["-Tpng", "-K" ++ layout, "-o" ++ filename] content
+                                  "dot" ["-Tpng", "-K" <> layout, "-o" <> unpack filename] $ unpack content
                 return $ case ec of
                            ExitSuccess -> Para [Image (id, [], []) [Str content] (filename, id)]
-                           _ -> CodeBlock (id, classes, keyvals) err
+                           _ -> CodeBlock (id, classes, keyvals) $ pack err
               where
-                uniq = ((showDigest . sha256 . fromString) (layout ++ "/" ++ content))
-                filename = "graphviz-" ++ uniq ++ ".png"
+                uniq = ((pack . showDigest . sha256 . encodeUtf8 . fromStrict) (pack layout <> "/" <> content))
+                filename = "graphviz-" <> uniq <> ".png"
     where
-      layout =
+      layout = unpack $
           case lookup "layout" keyvals of
             Just x -> x
             _ -> "dot"

--- a/README.md
+++ b/README.md
@@ -15,19 +15,17 @@ This filter provides Graphviz code block support.
 - graphviz
 - dot2tex (pdf/LaTeX support)
 
-On Debian, you can install the required packages as follows:
+## Installation
+Install using [Cabal](https://www.haskell.org/cabal/) 3.0 or later
+
+### Build and install filter
+
 ```
-$ sudo apt install pandoc graphviz dot2tex ghc libghc-utf8-string-dev libghc-sha-dev libghc-pandoc-dev
+$ cd pandoc-filter-graphviz
+$ cabal install pandoc-filter-graphviz
 ```
 
 ## Setup
-
-### Build filter
-```
-$ cd pandoc-filter-graphviz
-$ ghc --make Main.hs -o pandoc-filter-graphviz
-```
-Note: `-dynamic` option is required in some environments.
 
 ### Add TikZ to LaTeX template
 You can skip this step if you do not use pdf/LaTeX.
@@ -55,5 +53,5 @@ You can skip this step if you do not use pdf/LaTeX.
 
 ## Usage
 ```
-$ pandoc -F ./pandoc-filter-graphviz example.md -o example.html
+$ pandoc -F pandoc-filter-graphviz example.md -o example.html
 ```

--- a/pandoc-filter-graphviz.cabal
+++ b/pandoc-filter-graphviz.cabal
@@ -1,0 +1,40 @@
+name:                pandoc-filter-graphviz
+version:             0.1.0.0
+synopsis:            This filter provides Graphviz code block support.
+homepage:            https://github.com/Hakuyume/pandoc-filter-graphviz
+license:             BSD3
+license-file:        LICENSE
+author:              Toru Ogawa
+copyright:           BSD3
+category:            Text
+build-type:          Simple
+extra-source-files:  README.md
+cabal-version:       >=2.0
+
+executable pandoc-filter-graphviz
+  main-is:             Main.hs
+  other-modules:
+    GraphvizBlock
+
+  build-depends:
+     base         == 4.*
+   , utf8-string  ^>= 1.0.1.1
+   , SHA          ^>= 1.6.4.4
+   , text         ^>= 1.2.4.0
+   , process      ^>= 1.6.8.0
+   , pandoc-types ^>= 1.20
+
+  default-language:    Haskell2010
+
+  ghc-options:         -Wall
+                       -threaded
+                       -rtsopts
+                       -with-rtsopts=-N
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wcompat
+                       -Widentities
+                       -Wredundant-constraints
+                       -fhide-source-paths
+                       -Wmissing-export-lists
+                       -Wpartial-fields


### PR DESCRIPTION
I needed this, so I updated it since pandoc uses `Text` and added a cabal file for cabal new-builds.